### PR TITLE
Add the option to disable certificate verification

### DIFF
--- a/tasks/add_redhat_role_repos.yml
+++ b/tasks/add_redhat_role_repos.yml
@@ -4,6 +4,7 @@
     name:
       "{{ item.url }}"
     state: "{{ item.state | default('present') }}"
+    validate_certs: "{{ item.validate_certs | default( true ) }}"
   register: url_repos
   with_items:
     "{{ repositories.redhat }}"


### PR DESCRIPTION
When attemting to run this role in an airgapped network in a docker
container, not all of the certificates will validate. This adds the
options to set a flag in the dictionary to disable this verification.
By default verification is still enabled.